### PR TITLE
Implement Initial UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "author": "robbawebba",
   "license": "MIT",
   "dependencies": {
-    "material-ui": "^0.18.1",
+    "material-ui": "^1.0.0-alpha.16",
+    "material-ui-icons": "^1.0.0-alpha.3",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "react-tap-event-plugin": "^2.0.1"

--- a/src/client/app/components/header.jsx
+++ b/src/client/app/components/header.jsx
@@ -1,11 +1,20 @@
-import AppBar from 'material-ui/AppBar';
 import React from 'react';
+import AppBar from 'material-ui/AppBar';
+import Toolbar from 'material-ui/Toolbar';
+import Typography from 'material-ui/Typography';
+import Button from 'material-ui/Button';
+import IconButton from 'material-ui/IconButton';
+import MenuIcon from 'material-ui-icons/Menu';
 
 const Header = () => (
-  <AppBar
-    title="To-Do"
-    iconClassNameRight="muidocs-icon-navigation-expand-more"
-  />
+  <AppBar>
+        <Toolbar>
+          <IconButton contrast>
+            <MenuIcon />
+          </IconButton>
+          <Typography type="title" colorInherit>Title</Typography>
+        </Toolbar>
+      </AppBar>
 );
 
 export default Header;

--- a/src/client/app/components/header.jsx
+++ b/src/client/app/components/header.jsx
@@ -5,16 +5,40 @@ import Typography from 'material-ui/Typography';
 import Button from 'material-ui/Button';
 import IconButton from 'material-ui/IconButton';
 import MenuIcon from 'material-ui-icons/Menu';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 
-const Header = () => (
-  <AppBar>
-        <Toolbar>
-          <IconButton contrast>
-            <MenuIcon />
-          </IconButton>
-          <Typography type="title" colorInherit>Title</Typography>
-        </Toolbar>
-      </AppBar>
-);
+const styleSheet = createStyleSheet('Header', {
+  toolbar: {
+    position: 'fixed'
+  },
+  root: {
+      position: 'relative',
+      marginTop: 100,
+      width: '100%'
+  },
+  flex: {
+    flex: 1
+  }
+})
 
-export default Header;
+class Header extends React.Component {
+  render() {
+    const classes = this.props.classes
+    return (
+      <div className={classes.root}>
+        <AppBar className={classes.toolbar}>
+          <Toolbar>
+          {
+            //<IconButton contrast>
+              //<MenuIcon />
+            //</IconButton>
+          }
+            <Typography className={classes.flex} type="title" colorInherit>To-Do</Typography>
+          </Toolbar>
+        </AppBar>
+      </div>
+    )
+  }
+}
+
+export default withStyles(styleSheet)(Header);

--- a/src/client/app/components/todoItem.jsx
+++ b/src/client/app/components/todoItem.jsx
@@ -1,9 +1,20 @@
 import React, {Component} from 'react'
+import {
+  ListItem,
+  ListItemText,
+} from 'material-ui/List';
+import Checkbox from 'material-ui/Checkbox';
 
 class TodoItem extends Component {
   render() {
     return (
-      
+      <ListItem button>
+        <Checkbox
+          ripple={true}
+          checked={this.props.completed}
+        />
+        <ListItemText primary={this.props.title} />
+      </ListItem>
     )
   }
 }

--- a/src/client/app/components/todoItem.jsx
+++ b/src/client/app/components/todoItem.jsx
@@ -1,0 +1,12 @@
+import React, {Component} from 'react'
+
+class TodoItem extends Component {
+  render() {
+    return (
+      
+    )
+  }
+}
+
+
+export default TodoItem

--- a/src/client/app/components/todoList.jsx
+++ b/src/client/app/components/todoList.jsx
@@ -7,49 +7,36 @@ import List, {
 import Grid from 'material-ui/Grid';
 import Paper from 'material-ui/Paper';
 import FolderIcon from 'material-ui-icons/Folder';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
+
+import TodoItem from './TodoItem'
+
+const styleSheet = createStyleSheet('TodoList', theme => ({
+  root: {
+    width: '100%',
+    maxWidth: 360,
+    background: theme.palette.background.paper,
+  },
+}));
 
 class TodoList extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      testItems: [{title: "Say Hello", completed: false},{title: "Meet a new Friend", completed: true},{title: "Add redux logic", completed: false}]
+    }
+  }
   render() {
+    const classes = this.props.classes;
+    console.log(this.state)
     return (
-      <Grid item>
+      <Grid item className={classes.root}>
         <Paper>
           <List dense={false}>
-            <ListItem button>
-              <ListItemIcon>
-                <FolderIcon />
-              </ListItemIcon>
-              <ListItemText
-                primary="To-do Item"
-                secondary='Secondary text'
-              />
-            </ListItem>
-            <ListItem button>
-              <ListItemIcon>
-                <FolderIcon />
-              </ListItemIcon>
-              <ListItemText
-                primary="To-do Item 2"
-                secondary='Secondary text'
-              />
-            </ListItem>
-            <ListItem button>
-              <ListItemIcon>
-                <FolderIcon />
-              </ListItemIcon>
-              <ListItemText
-                primary="To-do Item 3"
-                secondary='Secondary text'
-              />
-            </ListItem>
-            <ListItem button>
-              <ListItemIcon>
-                <FolderIcon />
-              </ListItemIcon>
-              <ListItemText
-                primary="To-do Item 4"
-                secondary='Secondary text'
-              />
-            </ListItem>
+            {this.state.testItems.map((item) => {
+                return <TodoItem title={item.title} completed={item.completed} />
+              })
+            }
           </List>
         </Paper>
       </Grid>
@@ -58,4 +45,4 @@ class TodoList extends Component {
 }
 
 
-export default TodoList
+export default withStyles(styleSheet)(TodoList);

--- a/src/client/app/components/todoList.jsx
+++ b/src/client/app/components/todoList.jsx
@@ -1,0 +1,61 @@
+import React, {Component} from 'react'
+import List, {
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+} from 'material-ui/List';
+import Grid from 'material-ui/Grid';
+import Paper from 'material-ui/Paper';
+import FolderIcon from 'material-ui-icons/Folder';
+
+class TodoList extends Component {
+  render() {
+    return (
+      <Grid item>
+        <Paper>
+          <List dense={false}>
+            <ListItem button>
+              <ListItemIcon>
+                <FolderIcon />
+              </ListItemIcon>
+              <ListItemText
+                primary="To-do Item"
+                secondary='Secondary text'
+              />
+            </ListItem>
+            <ListItem button>
+              <ListItemIcon>
+                <FolderIcon />
+              </ListItemIcon>
+              <ListItemText
+                primary="To-do Item 2"
+                secondary='Secondary text'
+              />
+            </ListItem>
+            <ListItem button>
+              <ListItemIcon>
+                <FolderIcon />
+              </ListItemIcon>
+              <ListItemText
+                primary="To-do Item 3"
+                secondary='Secondary text'
+              />
+            </ListItem>
+            <ListItem button>
+              <ListItemIcon>
+                <FolderIcon />
+              </ListItemIcon>
+              <ListItemText
+                primary="To-do Item 4"
+                secondary='Secondary text'
+              />
+            </ListItem>
+          </List>
+        </Paper>
+      </Grid>
+    )
+  }
+}
+
+
+export default TodoList

--- a/src/client/app/index.html
+++ b/src/client/app/index.html
@@ -5,6 +5,11 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons"
+      rel="stylesheet">
+    <style>
+      body {margin: 0px }
+    </style>
   </head>
   <body>
     <div id="app" />

--- a/src/client/app/index.jsx
+++ b/src/client/app/index.jsx
@@ -20,8 +20,7 @@ class App extends Component {
           align={'center'}
           direction={'column'}
           justify={'flex-start'}>
-
-          <TodoList/>
+          <Grid item xs={12} md={12} sm={12}><TodoList/></Grid>
         </Grid>
       </div>
     )

--- a/src/client/app/index.jsx
+++ b/src/client/app/index.jsx
@@ -2,8 +2,10 @@ import React, { Component } from 'react'
 import { render } from 'react-dom'
 import injectTapEventPlugin from 'react-tap-event-plugin'
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
+import Grid from 'material-ui/Grid';
 
 import Header from './components/header'
+import TodoList from './components/todoList'
 
 // Needed for onTouchTap
 // http://stackoverflow.com/a/34015469/988941
@@ -12,11 +14,18 @@ injectTapEventPlugin();
 class App extends Component {
   render() {
     return (
-      <MuiThemeProvider>
-        <Header />
-      </MuiThemeProvider>
+      <div>
+        <Header/>
+        <Grid container
+          align={'center'}
+          direction={'column'}
+          justify={'flex-start'}>
+
+          <TodoList/>
+        </Grid>
+      </div>
     )
   }
 }
 
-render(<App />, document.getElementById('app'))
+render(<MuiThemeProvider><App /></MuiThemeProvider>, document.getElementById('app'))


### PR DESCRIPTION
This PR adds the initial presentational components necessary to display to-do list data. The next step is to add redux logic and container (stateful) components that work with the redux store. 

* To run the app, use the usual `npm install && npm start`
* This app uses the [Material-UI component library](https://github.com/callemall/material-ui/). I'm targeting the 1.0.0 alpha version since that version adds a `Grid` component that I found useful for this application. The code for 1.0.0 is located on the `next` branch. 
  * you can read more about the next release on their [roadmap](https://github.com/callemall/material-ui/blob/master/ROADMAP.md)
  * Here's [the documentation](https://material-ui-1dab0.firebaseapp.com/) that accompanies the new version

* **disclaimer**: The checkboxes on the dodo list don't work since I don't have callbacks yet. Those'll be added when I create the container components